### PR TITLE
gemspec: Make the required Ruby version 2.4.0+

### DIFF
--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday-net_http'
   spec.license = 'MIT'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
   spec.metadata['allowed_push_host'] = 'TODO: Set to \'http://mygemserver.com\''
 


### PR DESCRIPTION
This PR updates the required Ruby version to run this gem to _the same_ as Faraday 1.0 (which is a dependency).

Faraday 1.0 requires 2.4, so we still need that high a version.