### PR TITLE
allow configuration of ciphers option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@
 
 source 'https://rubygems.org'
 gemspec
+git_source(:github) { |project| File.join('https://github.com', "#{project}.git") }
+
+gem 'faraday', github: 'apneadiving/faraday', branch: 'ciphers-option'

--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -22,9 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'faraday', '~> 1.0'
-
-  spec.add_development_dependency 'bundler', '~> 2.0'
+  # spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.19.0'

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -168,6 +168,7 @@ module Faraday
         http.ssl_version = ssl[:version] if ssl[:version]
         http.min_version = ssl[:min_version] if ssl[:min_version]
         http.max_version = ssl[:max_version] if ssl[:max_version]
+        http.ciphers = ssl[:ciphers] if ssl[:ciphers]
       end
 
       def configure_request(http, req)


### PR DESCRIPTION
Context: I have to work with a server which has an old SSL cert. 

So by default, the open ssl configuration rejects the request with a message like: 
```
Faraday::SSLError (SSL_connect returned=1 errno=0 state=error: dh key too small)
```
One could patch the `/etc/ssl/openssl.cnf` file but I prefer to open the configuration at ruby level using:
```
http.ciphers = 'DEFAULT:!DH'
```
This allows a per-request setting.