### PR TITLE
Add dependency on net-http gem

### DIFF
--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'net-http', '~> 0.1'
+
   spec.add_development_dependency 'faraday', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
As described in https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/, Ruby
3.0.0 promoted net-http from stdlib. Adding this as a dependency avoids
"already initialized constant errors" if net-imap or some other gem is
included. See https://github.com/ruby/net-imap/issues/16#issuecomment-803086765 for
more details.