### PR TITLE
Update gem to be compatible with Faraday 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0']
 
     steps:
       - uses: actions/checkout@v1

--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
-require 'faraday_net_http'
+require 'faraday/net_http'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 2.0.0.alpha-2'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'lib/faraday/net_http/version'
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'faraday/net_http/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'faraday-net_http'

--- a/lib/faraday/net_http.rb
+++ b/lib/faraday/net_http.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'faraday'
 require_relative 'adapter/net_http'
 require_relative 'net_http/version'
 

--- a/lib/faraday/net_http.rb
+++ b/lib/faraday/net_http.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require_relative 'adapter/net_http'
-require_relative 'net_http/version'
+require 'faraday/adapter/net_http'
+require 'faraday/net_http/version'
 
 module Faraday
   module NetHttp


### PR DESCRIPTION
## Summary

Faraday 2.0 Alpha is here 🎉 !
This PR makes Faraday a proper dependency of this gem (no more cycle dependency issues).
The `gemspec` currently points to the alpha release, but will be updated before releasing the final 2.0 version of this gem

cc @mattbrictson