### PR TITLE
refactor: CI: Inline scripts, cache gems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, setup-ci]
+    branches: [main]
   schedule:
     - cron: '0 8 * * 1' # At 8:00 on Monday
 
@@ -21,11 +21,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Rubocop
-        run: |
-          bin/setup
-          bin/ci-lint
+        run: bundle exec rubocop --format progress
 
   test:
     needs: [lint]
@@ -41,11 +40,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Build
-        run: |
-          bin/setup
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Test
-        run: |
-          bin/ci-test
+        run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ gemfile.lock
 .ruby-version
 
 .rspec_status
+Gemfile.lock

--- a/bin/ci-lint
+++ b/bin/ci-lint
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
-
-bundle exec rubocop --format progress

--- a/bin/ci-test
+++ b/bin/ci-test
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
-
-bundle exec rspec


### PR DESCRIPTION
This PR inlines a few scripts, and adds bundler-cache to have installation from setup-ruby.

Removed development branch `setup-ci` from configuration.