### PR TITLE
fix: gemspec metadata for changelog notes

### DIFF
--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-net_http'
-  spec.metadata['changelog_uri'] = 'https://github.com/lostisland/faraday-net_http'
+  spec.metadata['changelog_uri'] = "https://github.com/lostisland/faraday-net_http/releases/tag/v#{spec.version}"
 
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']


### PR DESCRIPTION
This becomes e.g. https://github.com/lostisland/faraday-net_http/releases/tag/v1.0.1 and is used in the RubyGems sidebar.