### PR TITLE
Honor Content-Type charset

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 
 Metrics/BlockLength:
   Exclude:

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -62,13 +62,11 @@ module Faraday
       def call(env)
         super
         http_response = connection(env) do |http|
-          begin
-            perform_request(http, env)
-          rescue *NET_HTTP_EXCEPTIONS => e
-            raise Faraday::SSLError, e if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
+          perform_request(http, env)
+        rescue *NET_HTTP_EXCEPTIONS => e
+          raise Faraday::SSLError, e if defined?(OpenSSL) && e.is_a?(OpenSSL::SSL::SSLError)
 
-            raise Faraday::ConnectionFailed, e
-          end
+          raise Faraday::ConnectionFailed, e
         end
 
         save_response(env, http_response.code.to_i,
@@ -211,8 +209,8 @@ module Faraday
 
       def encoded_body(http_response)
         body = http_response.body || +''
-        /\bcharset=\s*(.+?)\s*(;|$)/.match(http_response['Content-Type']) do
-          content_charset = Encoding.find($1)
+        /\bcharset=\s*(.+?)\s*(;|$)/.match(http_response['Content-Type']) do |match|
+          content_charset = Encoding.find(match.captures.first)
           body = body.dup if body.frozen?
           body.force_encoding(content_charset)
         rescue ArgumentError

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -65,4 +65,57 @@ RSpec.describe Faraday::Adapter::NetHttp do
       end
     end
   end
+
+  context 'encoding' do
+    let(:connection) do
+      Faraday.new('http://example.com') { |conn| conn.adapter :net_http }
+    end
+
+    before do
+      stub_request(:get, 'http://example.com')
+        .to_return(
+          status: 200,
+          body: String.new('<msg>不在白名单内，请联系自我游</msg>', encoding: 'ASCII-8BIT'),
+          headers: headers
+        )
+    end
+
+    subject(:response) { connection.get }
+
+    context 'when Content-Type charset is UTF-8' do
+      let(:headers) { { 'Content-Type' => 'text/xml; charset=UTF-8' } }
+
+      it { expect(response.body.encoding).to eq(Encoding::UTF_8) }
+    end
+
+    context 'when Content-Type charset is ISO-8859-1' do
+      let(:headers) { { 'Content-Type' => 'text/html; charset=ISO-8859-1' } }
+
+      it { expect(response.body.encoding).to eq(Encoding::ISO_8859_1) }
+    end
+
+    context 'when Content-Type charset is Shift_JIS' do
+      let(:headers) { { 'Content-Type' => 'text/html; charset=Shift_JIS' } }
+
+      it { expect(response.body.encoding).to eq(Encoding::Shift_JIS) }
+    end
+
+    context 'when Content-Type is not given' do
+      let(:headers) { {} }
+
+      it { expect(response.body.encoding).to eq(Encoding::ASCII_8BIT) }
+    end
+
+    context 'when Content-Type charset is unknown' do
+      let(:headers) { { 'Content-Type' => 'text/xml; charset=BLABLA-8BIT' } }
+
+      it { expect(response.body.encoding).to eq(Encoding::ASCII_8BIT) }
+    end
+
+    context 'when Content-Type is empty' do
+      let(:headers) { { 'Content-Type' => '' } }
+
+      it { expect(response.body.encoding).to eq(Encoding::ASCII_8BIT) }
+    end
+  end
 end


### PR DESCRIPTION
## Description

Closes https://github.com/lostisland/faraday-net_http/issues/6

The `Net::HTTP` adapter does not seem to do any encoding transformation of the body string when the Content-Type charset is given. Forcing encoding on the response body has been picked as a workaround for that.