### PR TITLE
Anchor Encoding references to avoid faraday-encoding conflicts

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -210,7 +210,7 @@ module Faraday
       def encoded_body(http_response)
         body = http_response.body || +''
         /\bcharset=\s*(.+?)\s*(;|$)/.match(http_response['Content-Type']) do |match|
-          content_charset = Encoding.find(match.captures.first)
+          content_charset = ::Encoding.find(match.captures.first)
           body = body.dup if body.frozen?
           body.force_encoding(content_charset)
         rescue ArgumentError

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -85,37 +85,37 @@ RSpec.describe Faraday::Adapter::NetHttp do
     context 'when Content-Type charset is UTF-8' do
       let(:headers) { { 'Content-Type' => 'text/xml; charset=UTF-8' } }
 
-      it { expect(response.body.encoding).to eq(Encoding::UTF_8) }
+      it { expect(response.body.encoding).to eq(::Encoding::UTF_8) }
     end
 
     context 'when Content-Type charset is ISO-8859-1' do
       let(:headers) { { 'Content-Type' => 'text/html; charset=ISO-8859-1' } }
 
-      it { expect(response.body.encoding).to eq(Encoding::ISO_8859_1) }
+      it { expect(response.body.encoding).to eq(::Encoding::ISO_8859_1) }
     end
 
     context 'when Content-Type charset is Shift_JIS' do
       let(:headers) { { 'Content-Type' => 'text/html; charset=Shift_JIS' } }
 
-      it { expect(response.body.encoding).to eq(Encoding::Shift_JIS) }
+      it { expect(response.body.encoding).to eq(::Encoding::Shift_JIS) }
     end
 
     context 'when Content-Type is not given' do
       let(:headers) { {} }
 
-      it { expect(response.body.encoding).to eq(Encoding::ASCII_8BIT) }
+      it { expect(response.body.encoding).to eq(::Encoding::ASCII_8BIT) }
     end
 
     context 'when Content-Type charset is unknown' do
       let(:headers) { { 'Content-Type' => 'text/xml; charset=BLABLA-8BIT' } }
 
-      it { expect(response.body.encoding).to eq(Encoding::ASCII_8BIT) }
+      it { expect(response.body.encoding).to eq(::Encoding::ASCII_8BIT) }
     end
 
     context 'when Content-Type is empty' do
       let(:headers) { { 'Content-Type' => '' } }
 
-      it { expect(response.body.encoding).to eq(Encoding::ASCII_8BIT) }
+      it { expect(response.body.encoding).to eq(::Encoding::ASCII_8BIT) }
     end
   end
 end


### PR DESCRIPTION
This adds an explicit top-level namespace identification to all `Encoding` references (via `::Encoding`) in this library.

This change ensures that the top-level, Ruby-provided `Encoding` class is used rather than a [`faraday-encoding`](https://rubygems.org/gems/faraday-encoding)-defined `Faraday::Encoding` class if both libraries are loaded in an application.

See #17.