### PR TITLE
Add `Errno::EALREADY` to list of Net::HTTP exceptions

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -15,6 +15,7 @@ module Faraday
       exceptions = [
         IOError,
         Errno::EADDRNOTAVAIL,
+        Errno::EALREADY,
         Errno::ECONNABORTED,
         Errno::ECONNREFUSED,
         Errno::ECONNRESET,


### PR DESCRIPTION
Fixes #20