### PR TITLE
fix redos

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -190,8 +190,8 @@ module Faraday
 
       def encoded_body(http_response)
         body = http_response.body || +''
-        /\bcharset=\s*(.+?)\s*(;|$)/.match(http_response['Content-Type']) do |match|
-          content_charset = ::Encoding.find(match.captures.first)
+        /\bcharset=(.+)/.match(http_response['Content-Type']) do |match|
+          content_charset = ::Encoding.find(match.captures.first.split(';').first.strip)
           body = body.dup if body.frozen?
           body.force_encoding(content_charset)
         rescue ArgumentError

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -131,5 +131,11 @@ RSpec.describe Faraday::Adapter::NetHttp do
 
       it { expect(response.body.encoding).to eq(::Encoding::ASCII_8BIT) }
     end
+
+    context 'when Content-Type charset is UTF-8 and space' do
+      let(:headers) { { 'Content-Type' => 'text/xml; charset= UTF-8 ' } }
+
+      it { expect(response.body.encoding).to eq(::Encoding::UTF_8) }
+    end
   end
 end


### PR DESCRIPTION
Fixed ReDoS when receiving crafted response headers.

### PoC

```ruby
require 'benchmark'

def attack_text(length)
  text = 'charset=' + "\t" * length + "a" + "\t" * length + "a"
  /\bcharset=\s*(.+?)\s*(;|$)/.match(text)
end

Benchmark.bm do |x|
  x.report { attack_text(10) }
  x.report { attack_text(100) }
  x.report { attack_text(1000) }
  x.report { attack_text(10000) }
  x.report { attack_text(100000) }
end
```

```
❯ bundle exec ruby encoded_body_benchmark.rb
       user     system      total        real
   0.000009   0.000001   0.000010 (  0.000006)
   0.000062   0.000001   0.000063 (  0.000063)
   0.005081   0.000026   0.005107 (  0.005110)
   0.513256   0.001069   0.514325 (  0.514344)
  53.361165   0.264545  53.625710 ( 53.686721)
```