### PR TITLE
Add net-http dependency to gemspec.

### DIFF
--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'faraday', '>= 2.5'
+  spec.add_runtime_dependency 'net-http'
 end


### PR DESCRIPTION
As suggested at https://github.com/ruby/net-imap/issues/16#issuecomment-803086765. It prevents double-loads as the one happening at [Rails CI](https://buildkite.com/rails/rails/builds/94539#0186c67a-4538-4e1c-846c-99041daa2abe/1144-1148).

Regarding https://github.com/lostisland/faraday-net_http/issues/7#issuecomment-956070691, gem is locked to Ruby 2.6+ and net-http gem is locked to Ruby 2.6+ as well.

