### PR TITLE
net_http adapter: Fix to avoid calling `configure_ssl` for HTTP connections

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -42,8 +42,9 @@ module Faraday
 
       def build_connection(env)
         net_http_connection(env).tap do |http|
-          http.use_ssl = env[:url].scheme == 'https' if http.respond_to?(:use_ssl=)
-          configure_ssl(http, env[:ssl])
+          if env[:url].scheme == 'https' && env[:ssl]
+            configure_ssl(http, env[:ssl])
+          end
           configure_request(http, env[:request])
         end
       end
@@ -129,7 +130,7 @@ module Faraday
       end
 
       def configure_ssl(http, ssl)
-        return unless ssl
+        http.use_ssl = true if http.respond_to?(:use_ssl=)
 
         http.verify_mode = ssl_verify_mode(ssl)
         http.cert_store = ssl_cert_store(ssl)

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -12,9 +12,14 @@ RSpec.describe Faraday::Adapter::NetHttp do
   context 'checking http' do
     let(:url) { URI('http://example.com') }
     let(:adapter) { described_class.new }
-    let(:http) { adapter.send(:connection, url: url, request: {}) }
+    let(:ssl) { Faraday::SSLOptions.new }
+    let(:http) { adapter.send(:connection, url: url, request: {}, ssl: ssl) }
 
     it { expect(http.port).to eq(80) }
+
+    it { expect(http).not_to be_use_ssl }
+
+    it { expect(http.cert_store).to be_nil }
 
     it 'sets max_retries to 0' do
       adapter.send(:configure_request, http, {})
@@ -49,6 +54,10 @@ RSpec.describe Faraday::Adapter::NetHttp do
       end
 
       it { expect(http.port).to eq(443) }
+
+      it { expect(http).to be_use_ssl }
+
+      it { expect(http.cert_store).not_to be_nil }
 
       if Gem::Version.new(Faraday::VERSION) > Gem::Version.new('2.3.0') &&
          Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')


### PR DESCRIPTION
`env[:ssl]` is an instance of `Faraday::SSLOptions`, and as a result, `configure_ssl` is always executed, even when the connection is to HTTP. This MR fixes the code so that SSL configuration is only performed when necessary, similar to other adapters such as faraday-httpclient and faraday-patron.

Details can be found in #37 .

