### PR TITLE
net_http adapter: Backport the code of #38 to version 1.0.1

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -41,8 +41,9 @@ module Faraday
 
       def build_connection(env)
         net_http_connection(env).tap do |http|
-          http.use_ssl = env[:url].scheme == 'https' if http.respond_to?(:use_ssl=)
-          configure_ssl(http, env[:ssl])
+          if env[:url].scheme == 'https' && env[:ssl]
+            configure_ssl(http, env[:ssl])
+          end
           configure_request(http, env[:request])
         end
       end
@@ -155,7 +156,7 @@ module Faraday
       end
 
       def configure_ssl(http, ssl)
-        return unless ssl
+        http.use_ssl = true if http.respond_to?(:use_ssl=)
 
         http.verify_mode = ssl_verify_mode(ssl)
         http.cert_store = ssl_cert_store(ssl)

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -12,9 +12,14 @@ RSpec.describe Faraday::Adapter::NetHttp do
   context 'checking http' do
     let(:url) { URI('http://example.com') }
     let(:adapter) { described_class.new }
-    let(:http) { adapter.send(:connection, url: url, request: {}) }
+    let(:ssl) { Faraday::SSLOptions.new }
+    let(:http) { adapter.send(:connection, url: url, request: {}, ssl: ssl) }
 
     it { expect(http.port).to eq(80) }
+
+    it { expect(http).not_to be_use_ssl }
+
+    it { expect(http.cert_store).to be_nil }
 
     it 'sets max_retries to 0' do
       adapter.send(:configure_request, http, {})
@@ -44,6 +49,10 @@ RSpec.describe Faraday::Adapter::NetHttp do
       let(:url) { URI('https://example.com') }
 
       it { expect(http.port).to eq(443) }
+
+      it { expect(http).to be_use_ssl }
+
+      it { expect(http.cert_store).not_to be_nil }
     end
 
     context 'with http url including port' do


### PR DESCRIPTION
This PR is the backport of #38 to version v1.0.1 . 

Could you create a branch for version 1.0.1 (something like 1.x)? I've temporarily set the target branch to main, but I will change the target branch of the PR to the new one afterwards.