### PR TITLE
Opt-in for MFA requirement explicitly

### DIFF
--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-net_http'
   spec.metadata['changelog_uri'] = "https://github.com/lostisland/faraday-net_http/releases/tag/v#{spec.version}"
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']


### PR DESCRIPTION
As a popular gem, `faraday-net_http` implicitly requires that all privileged operations by any of the owners require OTP.

However, by explicitly setting `rubygems_mfa_required` metadata, the gem will show "NEW VERSIONS REQUIRE MFA" and
"VERSION PUBLISHED WITH MFA" in the sidebar at
https://rubygems.org/gems/faraday-net_http

Ref:
- https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html
- https://guides.rubygems.org/mfa-requirement-opt-in/

---

![image](https://github.com/user-attachments/assets/8d3e8356-3325-4f7e-8cd9-3f0df080a72e)
