### PR TITLE
Run CI against `main` branch of Faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'faraday', github: 'lostisland/faraday'
+
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
 gem 'simplecov'

--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -25,6 +25,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'faraday', '>= 2.5'
   spec.add_runtime_dependency 'net-http'
 end


### PR DESCRIPTION
## Summary

This allows to test against new, unreleased versions of Faraday so that we can release faraday and faraday-net_http in tandem.