### PR TITLE
Add HTTPS Proxy support

### DIFF
--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'net-http'
+  spec.add_runtime_dependency 'net-http', '>= 0.5.0'
 end

--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -53,7 +53,8 @@ module Faraday
         if proxy
           Net::HTTP.new(env[:url].hostname, port,
                         proxy[:uri].hostname, proxy[:uri].port,
-                        proxy[:user], proxy[:password])
+                        proxy[:user], proxy[:password],
+                        proxy[:uri].scheme == 'https')
         else
           Net::HTTP.new(env[:url].hostname, port, nil)
         end


### PR DESCRIPTION
net-http version 0.5.0 finally introduced TLS proxy support: https://github.com/ruby/net-http/pull/55
https://github.com/ruby/net-http/releases/tag/v0.5.0

Since this change is breaking for older versions of net-http, I can also implement this in a backward compatible way.