### PR TITLE
Fix HTTPS proxy support

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -54,7 +54,7 @@ module Faraday
           Net::HTTP.new(env[:url].hostname, port,
                         proxy[:uri].hostname, proxy[:uri].port,
                         proxy[:user], proxy[:password],
-                        proxy[:uri].scheme == 'https')
+                        nil, proxy[:uri].scheme == 'https')
         else
           Net::HTTP.new(env[:url].hostname, port, nil)
         end

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -191,4 +191,52 @@ RSpec.describe Faraday::Adapter::NetHttp do
       it { expect(http.extra_chain_cert).to be_nil }
     end
   end
+
+  context 'http proxy' do
+    let(:adapter) { described_class.new }
+    let(:url) { URI('https://example.com') }
+    let(:proxy) { URI('http://proxy.example.com') }
+    let(:proxy_options) do
+      {
+        uri: proxy,
+        user: 'proxy_user',
+        password: 'proxy_pass'
+      }
+    end
+    let(:http) { adapter.send(:connection, url: url, request: { proxy: proxy_options }) }
+
+    it { expect(http.proxy_address).to eq 'proxy.example.com' }
+
+    it { expect(http.proxy_port).to be 80 }
+
+    it { expect(http.proxy_user).to eq 'proxy_user' }
+
+    it { expect(http.proxy_pass).to eq 'proxy_pass' }
+
+    it { expect(http.instance_variable_get(:@proxy_use_ssl)).to be false }
+  end
+
+  context 'https proxy' do
+    let(:adapter) { described_class.new }
+    let(:url) { URI('https://example.com') }
+    let(:proxy) { URI('https://proxy.example.com') }
+    let(:proxy_options) do
+      {
+        uri: proxy,
+        user: 'proxy_user',
+        password: 'proxy_pass'
+      }
+    end
+    let(:http) { adapter.send(:connection, url: url, request: { proxy: proxy_options }) }
+
+    it { expect(http.proxy_address).to eq 'proxy.example.com' }
+
+    it { expect(http.proxy_port).to be 443 }
+
+    it { expect(http.proxy_user).to eq 'proxy_user' }
+
+    it { expect(http.proxy_pass).to eq 'proxy_pass' }
+
+    it { expect(http.instance_variable_get(:@proxy_use_ssl)).to be true }
+  end
 end


### PR DESCRIPTION
Hey, I'd like to apologise for the oversight in #47. I miscounted the arguments to the existing `Net::HTTP` constructor, as I had only tested directly with the `Net::HTTP` object. I tested this change directly with the adapter, and it's correct now.

The `nil` argument is a ["Proxy Filter"](https://docs.ruby-lang.org/en/master/Net/HTTP.html#class-Net::HTTP-label-Filtering+Proxies). I think it's safe to disable as Faraday doesn't seem to support proxy filters.

Sorry again for the oversight