### PR TITLE
Use more conservative net-http version constraint

### DIFF
--- a/faraday-net_http.gemspec
+++ b/faraday-net_http.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'net-http', '>= 0.5.0'
+  spec.add_runtime_dependency 'net-http', '~> 0.5'
 end


### PR DESCRIPTION
## Summary

Changes the `net-http` dependency constraint from `>= 0.5.0` to `~> 0.5` to provide better protection against breaking changes in future major versions.

## Motivation

The current constraint `>= 0.5.0` is very permissive, as it allows any version upgrade, including major version bumps (1.0.0, 2.0.0, etc.) which could introduce breaking changes.

The new constraint `~> 0.5` provides better protection while maintaining flexibility:
- ✅ Allows all 0.x versions (0.5.x, 0.6.x, 0.7.x, etc.), giving downstream projects flexibility
- ✅ Blocks automatic upgrades to 1.0+ major versions, where breaking changes are expected
- ✅ Makes major version bumps more explicit in dependency update PRs

## Changes

```diff
- spec.add_runtime_dependency 'net-http', '>= 0.5.0'
+ spec.add_runtime_dependency 'net-http', '~> 0.5'
```

## ⚠️ Additional important context ⚠️

This change was prompted by a recent incident with https://github.com/ruby/net-http/releases/tag/v0.7.0, which introduced a breaking change (removal of automatic `Content-Type: application/x-www-form-urlencoded` header for requests with a body) but was released as a minor version bump. **Because of the permissive `>= 0.5.0` constraint in `faraday-net_http`, projects using it as a transitive dependency were automatically upgraded to this `0.7.0` version of `net-http` during unrelated dependency updates, causing unexpected production issues.**[^1]

## Further improvements

While `~> 0.5` still allows 0.7.x (since it permits all 0.x versions), it provides protection against future major versions. If you'd prefer even stricter protection, we could consider `~> 0.6` instead, which would block 0.7+ entirely. However, this might be too restrictive for projects that have already upgraded to `net-http` 0.7.

WDYT?

[^1]: Of course, the reviewer is ultimately responsible for checking all changes in the PR, including transitive dependencies. That said, bumping minor versions when introducing breaking changes makes it more likely such updates go unnoticed, raising the risk of unexpected production issues that are then particularly difficult to trace.