### PR TITLE
Always dup body before mutating it

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -187,11 +187,10 @@ module Faraday
       end
 
       def encoded_body(http_response)
-        body = http_response.body || +''
+        body = http_response.body || ''
         /\bcharset=([^;]+)/.match(http_response['Content-Type']) do |match|
           content_charset = ::Encoding.find(match[1].strip)
-          body = body.dup if body.frozen?
-          body.force_encoding(content_charset)
+          body = body.dup.force_encoding(content_charset)
         rescue ArgumentError
           nil
         end


### PR DESCRIPTION
Ref: https://github.com/lostisland/faraday-net_http/pull/13

`body = body.dup if body.frozen?` isn't a good pattern because while it works to not fail if the string is frozen, it doesn't prevent triggering deprecation warnings if the `body` happened to be a mutable literal string (AKA chilled string).

Either way, it's preferable to always dup the string, Ruby will take care to share the buffer instead of copying if the string is large enough.