### PR TITLE
Keep response body mutable when there is no body and no Content-Type

### DIFF
--- a/lib/faraday/adapter/net_http.rb
+++ b/lib/faraday/adapter/net_http.rb
@@ -187,7 +187,7 @@ module Faraday
       end
 
       def encoded_body(http_response)
-        body = http_response.body || ''
+        body = http_response.body || +''
         /\bcharset=([^;]+)/.match(http_response['Content-Type']) do |match|
           content_charset = ::Encoding.find(match[1].strip)
           body = body.dup.force_encoding(content_charset)

--- a/spec/faraday/adapter/net_http_spec.rb
+++ b/spec/faraday/adapter/net_http_spec.rb
@@ -148,6 +148,19 @@ RSpec.describe Faraday::Adapter::NetHttp do
     end
   end
 
+  context 'when the response has no body and no Content-Type' do
+    let(:adapter) { described_class.new }
+    let(:http_response) do
+      instance_double(Net::HTTPResponse, body: nil).tap do |response|
+        allow(response).to receive(:[]).with('Content-Type').and_return(nil)
+      end
+    end
+
+    it 'returns a mutable (non-frozen) body' do
+      expect(adapter.send(:encoded_body, http_response)).not_to be_frozen
+    end
+  end
+
   context 'client certificate' do
     let(:adapter) { described_class.new }
     let(:url) { URI('https://example.com') }


### PR DESCRIPTION
## Summary

[#56](https://github.com/lostisland/faraday-net_http/pull/56) changed the fallback in `encoded_body` from `+''` to `''`. Because `lib/faraday/adapter/net_http.rb` has `# frozen_string_literal: true`, the bare `''` literal is **frozen**. When a response has no body and no `Content-Type`, the `charset` match block never runs (so the body is never re-duped), and `encoded_body` returns the frozen empty string. This becomes `env.response_body`, and any downstream middleware that mutates the body raises `FrozenError`.

This was reported in [#56 (comment)](https://github.com/lostisland/faraday-net_http/pull/56#issuecomment-4567037817) and @byroot [confirmed](https://github.com/lostisland/faraday-net_http/pull/56#issuecomment-4568262541) that line 190 could be reverted. This restores the unary `+` so the fallback stays mutable, leaving the rest of #56 intact.

## Changes

- `lib/faraday/adapter/net_http.rb`: `http_response.body || ''` → `http_response.body || +''`
- Add a regression spec asserting `encoded_body` returns a non-frozen body when the response has no body and no `Content-Type`.

## Test plan

- [x] `bundle exec rspec` — 386 examples, 0 failures
- [x] New spec fails before the revert (frozen body) and passes after
- [x] `bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)